### PR TITLE
updated to ember CLI 0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # dependencies
 /node_modules
-/bower_components/*
+/bower_components
 
 # misc
 /.sass-cache

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,10 +1,9 @@
 {
-  "predef": {
-    "document": true,
-    "window": true,
-    "-Promise": true,
-    "DuvergerENV": true
-  },
+  "predef": [
+    "document",
+    "window",
+    "-Promise"
+  ],
   "browser" : true,
   "boss" : true,
   "curly": true,

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,6 +1,7 @@
 /* global require, module */
 
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
 var app = new EmberApp();
 
 // Use `app.import` to add additional libraries to the generated

--- a/app/index.html
+++ b/app/index.html
@@ -13,6 +13,8 @@
     <link rel="stylesheet" href="assets/duverger.css">
   </head>
   <body>
+    {{content-for 'body'}}
+
     <script src="assets/vendor.js"></script>
     <script src="assets/duverger.js"></script>
   </body>

--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,11 @@
   "dependencies": {
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
-    "ember": "components/ember#canary",
+    "ember": "1.7.0",
+    "ember-data": "1.0.0-beta.10",
     "ember-resolver": "~0.1.7",
     "loader.js": "stefanpenner/loader.js#1.0.1",
-    "ember-cli-shims": "stefanpenner/ember-cli-shims#canary",
+    "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
     "ember-qunit": "0.1.8",
@@ -19,6 +20,6 @@
     "neat": "1.5.0"
   },
   "resolutions": {
-    "ember": "canary"
+    "qunit": "~1.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test",
-    "postinstall": "bower install"
+    "test": "ember test"
   },
   "repository": "https://github.com/stefanpenner/ember-cli",
   "engines": {
@@ -19,24 +18,17 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "0.3.0",
-    "bower": "^1.3.4",
+    "body-parser": "^1.2.0",
+    "broccoli-asset-rev": "0.3.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "commander": "^2.3.0",
-    "ember-cli": "0.1.0",
+    "broccoli-sass": "^0.1.4",
+    "ember-cli": "0.1.2",
     "ember-cli-ic-ajax": "0.1.1",
-    "ember-cli-inject-live-reload": "^1.2.2",
+    "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.1.0",
+    "ember-data": "1.0.0-beta.10",
+    "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
     "glob": "^4.0.5"
-  },
-  "dependencies": {
-    "broccoli-sass": "^0.1.4",
-    "broccoli-static-compiler": "^0.2.0",
-    "broccoli-unwatched-tree": "^0.1.1",
-    "chalk": "^0.5.1",
-    "mime": "^1.2.11",
-    "rsvp": "^3.0.8",
-    "walk-sync": "^0.1.3"
   }
 }

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -39,7 +39,6 @@
     "findWithAssert",
     "wait",
     "DS",
-    "keyEvent",
     "isolatedContainer",
     "startApp",
     "andThen",

--- a/tests/index.html
+++ b/tests/index.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{content-for 'head'}}
+    {{content-for 'test-head'}}
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/duverger.css">
@@ -33,6 +34,8 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
 
+    {{content-for 'body'}}
+    {{content-for 'test-body'}}
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/duverger.js"></script>


### PR DESCRIPTION
Upgraded to ember CLI 0.1.2
- this uses ember 1.8 (instead of ember canary). there are some handlebars 2.0 issues that our app is encountering in handlebars 2.0 that break our app. Let's revisit later
