### PR TITLE
refactored formula drop down to not use a select

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -33,6 +33,10 @@ export default Ember.ObjectController.extend(ElectionOutcomeMixin, {
   }),
 
   actions: {
+    toggleFormulaList: function() {
+      var showFormulaList = get(this, 'showFormulaList');
+      set(this, 'showFormulaList', !showFormulaList);
+    },
     useFormula: function(option){
       var formulaName = option.value;
 
@@ -40,6 +44,7 @@ export default Ember.ObjectController.extend(ElectionOutcomeMixin, {
         set(this, 'currentRunoff', 0);
       }
       set(this, 'formulaName', formulaName);
+      set(this, 'showFormulaList', false);
     },
 
     recalculateElectionOutcome: function() {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -40,15 +40,17 @@
       </div>
 
       <div class="formula header--election--dropdown">
-        <div class="formula__label header--election__label">Formula Applied:</div>
-        <div class="formula__value header--election__value">
-          {{awesome-select
-            prompt='Select Formula'
-            options=model.formulae
-            initialValue=model.formulaName
-            on-change='useFormula'
-          }}
-        </div>
+        <div class="formula__label header--election__label">Formula Applied: <button class="toggle-formula-list-button" {{action 'toggleFormulaList'}}>Select formula</button></div>
+        <div class="selected-formula">{{model.formulaName}}</div>
+        {{#if showFormulaList}}
+          <ul class="formula-selector">
+            {{#each formula in model.formulae}}
+              <li class="formula-item">
+                <button {{action 'useFormula' formula}} class="select-formula-button">{{formula.display}}</button>
+              </li>
+            {{/each}}
+          </ul>
+        {{/if}}
       </div>
     </div>
 

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
-    "ember": "1.7.0",
+    "ember": "1.8.0",
     "ember-data": "1.0.0-beta.10",
     "ember-resolver": "~0.1.7",
     "loader.js": "stefanpenner/loader.js#1.0.1",
@@ -18,8 +18,5 @@
     "d3": "~3.4.11",
     "bourbon": "~3.2",
     "neat": "1.5.0"
-  },
-  "resolutions": {
-    "qunit": "~1.15.0"
   }
 }

--- a/tests/helpers/navigation.js
+++ b/tests/helpers/navigation.js
@@ -3,17 +3,15 @@ import Ember from 'ember';
 
 var registerAsyncHelper = Ember.Test.registerAsyncHelper;
 
-var formulaSelectSelector = '.formula select';
-var majorityFormulaOptionSelector = 'option';
+var toggleFormulaListButtonSelector = '.toggle-formula-list-button';
+var formulaButtonsSelector = '.select-formula-button';
 var runoffSelector = '.election-nav-btn.view-runoff';
 
-function selectDropdownOption(optionIndex) {
+function selectFromDropDown(buttonIndex) {
   return function() {
-    var select = find(formulaSelectSelector);
-    var option = select.find(majorityFormulaOptionSelector)[optionIndex];
-
-    $(option).prop('selected', true);
-    triggerEvent(select[0], 'change');
+    click(toggleFormulaListButtonSelector);
+    var formulaButtons = find(formulaButtonsSelector);
+    return click(formulaButtons[buttonIndex]);
   };
 }
 
@@ -21,7 +19,7 @@ registerAsyncHelper('navigateToMajorityRunoff', function(app, districtUrl) {
   var click = app.testHelpers.click;
 
   return visit(districtUrl)
-    .then(selectDropdownOption(1))
+    .then(selectFromDropDown(0))
     .then(function() {
       return click(runoffSelector);
     });
@@ -31,5 +29,5 @@ registerAsyncHelper('navigateToPlurality', function(app, districtUrl) {
   var click = app.testHelpers.click;
 
   return visit(districtUrl)
-    .then(selectDropdownOption(2));
+    .then(selectFromDropDown(1));
 });

--- a/tests/integration/district-display-test.js
+++ b/tests/integration/district-display-test.js
@@ -13,6 +13,7 @@ var formulaValueSelector = '.formula__value option';
 var districtValueSelector = '.district__value';
 var donutSvgSelector = '.donut-chart svg';
 var electionOutcomeSelector = '.party-winner.runoff';
+var selectedFormulaSelector = '.selected-formula';
 
 function assertChartDisplay(chartType) {
   return function() {
@@ -34,9 +35,8 @@ function assertElectionOutcome() {
 }
 
 function assertDefaultFormulaSelected() {
-  var formula = $(find(formulaValueSelector)[1]);
-  equal(formula.prop('selected'), true);
-  equal(formula.val(), 'majority');
+  var formula = find(selectedFormulaSelector);
+  equal(formula.text(), 'majority');
 }
 
 function assertDistrictDisplayed() {
@@ -131,7 +131,7 @@ test('preference parties are displayed', function() {
 });
 
 test('formula is displayed', function() {
-  expect(2);
+  expect(1);
   visit('/')
     .then(assertDefaultFormulaSelected);
 });

--- a/tests/integration/formula-test.js
+++ b/tests/integration/formula-test.js
@@ -12,6 +12,18 @@ var formulaDisplaySelector = '.formula';
 var formulaSelectSelector = '.formula select';
 var formulaOptionsSelector = 'option';
 var electionRoundButton = '.election-nav-btn';
+var toggleFormulaListButtonSelector = '.toggle-formula-list-button';
+var formulaButtonsSelector = '.select-formula-button';
+
+function assertDropDownIsHidden() {
+  var formulaButtons = find(formulaButtonsSelector);
+  ok(!formulaButtons.length, 'formula buttons are not displayed');
+}
+
+function assertDropDownIsVisible() {
+  var formulaButtons = find(formulaButtonsSelector);
+  equal(formulaButtons.length, 2, 'two formula buttons are displayed');
+}
 
 function assertChartDisplay(chartType) {
   return function() {
@@ -19,34 +31,14 @@ function assertChartDisplay(chartType) {
   };
 }
 
-function selectFromDropDown(optionIndex) {
-  return function() {
-    var select  = find(formulaSelectSelector);
-    var options = select.find(formulaOptionsSelector);
-    var option  = find(options[optionIndex]);
-
-    option.prop('selected', true);
-    triggerEvent(select[0], 'change');
-  };
+function showFormulaList() {
+  return click(toggleFormulaListButtonSelector);
 }
 
-function assertDropDownSelection(selectedOptionIndex) {
+function selectFromDropDown(buttonIndex) {
   return function() {
-    var select  = find(formulaSelectSelector);
-    var options = select.find(formulaOptionsSelector);
-    var option  = find(options[selectedOptionIndex]);
-
-    if (empty(selectedOptionIndex)) {
-      for (var i = 0; i < options.length; i++) {
-        if (i === 0) {
-          ok(find(options[i]).prop('selected'), 'the option is selected');
-        } else {
-          ok(!find(options[i]).prop('selected'), 'the option is not selected');
-        }
-      }
-    } else {
-      ok(find(option).prop('selected'), 'the option is selected');
-    }
+    var formulaButtons = find(formulaButtonsSelector);
+    return click(formulaButtons[buttonIndex]);
   };
 }
 
@@ -90,12 +82,14 @@ test('switch from majority to plurality and black', function() {
   expect(36);
 
   visit('/')
-    .then(selectFromDropDown(2))
-    .then(assertDropDownSelection(2))
+    .then(assertDropDownIsHidden)
+    .then(showFormulaList)
+    .then(assertDropDownIsVisible)
+    .then(selectFromDropDown(1))
     .then(assertChartDisplay('plurality'))
     .then(assertPartyWinners(['SD']))
-    .then(selectFromDropDown(1))
-    .then(assertDropDownSelection(1))
+    .then(showFormulaList)
+    .then(selectFromDropDown(0))
     .then(assertChartDisplay('majorityFirstRound'))
     .then(assertPartyWinners(['SD', 'G']))
     .then(assertElectionNavButtonExists);

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -102,7 +102,7 @@ test('when the voter amounts change, the election is recomputed', function() {
 });
 
 test('useFormula action sets the formulaName to the passed in formula', function(){
-  expect(1);
+  expect(2);
 
   var controller = this.subject({
     content: {}
@@ -114,6 +114,7 @@ test('useFormula action sets the formulaName to the passed in formula', function
 
   controller.send('useFormula', option);
   equal(get(controller, 'formulaName'), 'theory of relativity', 'the formulaName is correct');
+  ok(!get(controller, 'showFormulaList'), 'the value of showFormulaList is correct');
 });
 
 test('useFormula action sets the currentRunoff to 0 when the formula name is `plurality`', function() {
@@ -163,4 +164,22 @@ test('viewCurrentElection sets the currentRunoff to 0', function() {
 
   controller.send('viewCurrentElection');
   equal(get(controller, 'currentRunoff'), 0, 'the currentRunoff is correct');
+});
+
+test('toggleFormulaList action toggles showFormulaList property', function() {
+  expect(3);
+
+  var controller = this.subject({
+    content: {}
+  });
+
+  ok(!get(controller, 'showFormulaList'), 'the value of showFormulaList is correct');
+
+  controller.send('toggleFormulaList');
+
+  ok(get(controller, 'showFormulaList'), 'the value of showFormulaList is correct');
+
+  controller.send('toggleFormulaList');
+
+  ok(!get(controller, 'showFormulaList'), 'the value of showFormulaList is correct');
 });


### PR DESCRIPTION
refactored formula drop down to not use a select, so that they can be styled per the design.

Also updated to ember 1.8
